### PR TITLE
README: add a deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# PaddedMatrices
+# PaddedMatrices.jl
+# ⚠️ DEPRECATED: PaddedMatrices.jl is now deprecated in favor of [StrideArrays.jl](https://github.com/chriselrod/StrideArrays.jl)
 
 [![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://chriselrod.github.io/PaddedMatrices.jl/stable)
 [![Latest](https://img.shields.io/badge/docs-latest-blue.svg)](https://chriselrod.github.io/PaddedMatrices.jl/dev)


### PR DESCRIPTION
Here's what I recommend:
1. ~~Wait until https://github.com/JuliaRegistries/General/pull/28422 is auto-merged~~. Done.
2. Merge this pull request
3. See if there are any packages that still depend on PaddedMatrices
4. Migrate those packages to use StrideArrays instead
5. Close all issues and pull requests in the PaddedMatrices.jl repository
6. Archive the PaddedMatrices.jl repository